### PR TITLE
[Form] fix validation/help message margin top for dense elements

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -68,6 +68,10 @@
       padding-top: calc($spv-nudge - $spv--x-small - $input-border-thickness);
     }
 
+    &.is-dense + .p-form-validation__message, &.is-dense + .p-form-help-text {
+      margin-top: 0px;
+    }
+
     &[disabled],
     &[disabled='disabled'] {
       @extend %vf-disabled-element;


### PR DESCRIPTION
## Done

When an element is dense, the thelp text or the validation text has a top margin, which should be disabled.

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Fix : 
![image](https://github.com/pierre-H/vanilla-framework/assets/6079305/a0bf570f-0121-452c-b3a6-0de802c93613)

![image](https://github.com/pierre-H/vanilla-framework/assets/6079305/ae320799-4df6-4923-9a80-a609be4e1bfc)

